### PR TITLE
remove reference to malicious pypi package

### DIFF
--- a/¬
+++ b/¬
@@ -1,3 +1,3 @@
 #!/usr/bin/env python3
 
-import urlib3
+import urllib3


### PR DESCRIPTION
This might have been a typo, but `urlib3` (note how it's misspelled) is a (now-removed) typo-squatting malicious pypi package [1]

Since I imagine that many dev's (like myself) probably have just run `pip install urlib3` after seeing python's missing library error, you might want to make sure that `urlib3` (note the typo) is uninstalled from your computers.

Why am I sending this PR to a random repo?
idk; I'm just bored :P
same reason why I've written so much ¯\_(ツ)_/¯


[1] https://www.bleepingcomputer.com/news/security/ten-malicious-libraries-found-on-pypi-python-package-index/